### PR TITLE
feat: Added a function to check the button after scrolling to the end.

### DIFF
--- a/lesson24/src/index.html
+++ b/lesson24/src/index.html
@@ -32,7 +32,7 @@
       </form>
     </div>
     <div data-id="popup-modal" tabindex="-1" class="hidden modal" aria-hidden="true">
-            <div class="relative bg-white rounded-lg shadow overflow-y-auto h-96 p-4 w-full max-w-2xl" role="dialog" aria-modal="true" aria-labelledby="modal_title" aria-describedby="modal_body">
+            <div data-id="modal-inner" class="relative bg-white rounded-lg shadow overflow-y-auto h-96 p-4 w-full max-w-2xl" role="dialog" aria-modal="true" aria-labelledby="modal_title" aria-describedby="modal_body">
                 <button type="button" class="close_btn" data-id="close-button" data-modal-toggle="popup-modal">
                     <svg aria-hidden="true" class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
                       <path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd">

--- a/lesson24/src/index.html
+++ b/lesson24/src/index.html
@@ -249,7 +249,7 @@
                 </div>
               </div>
               <div class="my-4 text-center flex flex-col gap-3">
-                <button data-modal-toggle="popup-modal" type="button" class="agree_btn" data-id="agree_button">
+                <button data-modal-toggle="popup-modal" type="button" class="agree_btn" data-id="agree_button" disabled>
                   利用規約を最後まで読み、同意する
                 </button>
                 <button data-modal-toggle="popup-modal" class="cancel_button">

--- a/lesson24/src/js/main.js
+++ b/lesson24/src/js/main.js
@@ -73,4 +73,20 @@ submitButton.addEventListener("click", (e) => {
     window.location.href = "register-done.html";
 });
 
+const options = {
+    root: document.querySelector('[data-id="modal-inner"]'),
+};
+
+const removeDisabledForAgreeButton = (entries) => {
+    entries.forEach(entry => {
+        if(entry.isIntersecting){
+            const agreeButton  = document.querySelector('[data-id="agree_button"]');
+            agreeButton.removeAttribute('disabled');
+        }
+    });
+};
+
+const observer = new IntersectionObserver(removeDisabledForAgreeButton, options);
+observer.observe(document.querySelector('[data-id="last_text"]'));
+
 toggleModal();

--- a/lesson24/src/js/main.js
+++ b/lesson24/src/js/main.js
@@ -75,6 +75,7 @@ submitButton.addEventListener("click", (e) => {
 
 const options = {
     root: document.querySelector('[data-id="modal-inner"]'),
+    threshold: 1
 };
 
 const removeDisabledForAgreeButton = (entries) => {

--- a/lesson24/src/js/main.js
+++ b/lesson24/src/js/main.js
@@ -78,13 +78,11 @@ const options = {
     threshold: 1
 };
 
-const removeDisabledForAgreeButton = (entries) => {
-    entries.forEach(entry => {
-        if(entry.isIntersecting){
-            const agreeButton  = document.querySelector('[data-id="agree_button"]');
-            agreeButton.removeAttribute('disabled');
-        }
-    });
+const removeDisabledForAgreeButton = ([entry]) => {
+    if(entry.isIntersecting){
+        const agreeButton  = document.querySelector('[data-id="agree_button"]');
+        agreeButton.removeAttribute('disabled');
+    }
 };
 
 const observer = new IntersectionObserver(removeDisabledForAgreeButton, options);


### PR DESCRIPTION
# [Issue.24](https://github.com/kenmori/handsonFrontend/blob/master/work/markup/1.md#24)

## Specifications already implemented
The following specifications are not included in this PR.
> バリデーションはここではなし
ユーザー名、メールアドレス、パスワードの入力欄と利用規約に関するチェックボックス(画像参照)がある。
送信ボタンがあるが振るまいの実装はしないで良い
利用規約のテキストを押すと、モーダルが立ち上がり(前回作ったもので良い)、[ダミーの利用規約](https://terracetech.jp/2021/04/11/gakusyuuyousozairiyoukiyaku/)がテキストとして読める。
checkedがtrueの場合送信ボタンを押下すると別ページのregister-done.htmlに飛ぶ
register-done.htmlは画面のようなテキストになっている(画面は適当で、遷移できていることが分かれば良い。CSSも書かないでも良い)
これ以降の課題でログイン画面が登場する課題にはPRのわかりやすい所にユーザー名とpasswordなど示してください

## Specifications implemented this Pull Request
This PR is about this specification.
> スクロールが一番下に行ったらチェックボックスはcheckedになる。もし開いてもスクロールが下まで行っていなければcheckedはfalseのまま


## [CodeSandBox](https://codesandbox.io/s/github/nakagawamai/js-lesson/tree/feature/lesson24/lesson24) : [Latest Commit Link](https://github.com/nakagawamai/js-lesson/pull/26/commits/89567fd800ffe245b9399f1301f12b19577babf5)
## Concerns and areas to focus on
 I want to wait until the last line of article 15 is displayed as the event will be executed the moment the modal window shows the last text article 15.I would like to know how to solve this.

Thanks to Sae-san, I solved it.
https://github.com/nakagawamai/js-lesson/pull/26#discussion_r1011748597