### PR TITLE
Lesson26-4 fix login function.

### DIFF
--- a/lesson26/src/js/login.js
+++ b/lesson26/src/js/login.js
@@ -50,8 +50,8 @@ const login = async () => {
     }
     
     if (response.token) {
-        window.location.href = "./index.html";
         localStorage.setItem("token", JSON.stringify(response.token));
+        window.location.href = "./index.html";
     }
 }
 

--- a/lesson26/src/js/login.js
+++ b/lesson26/src/js/login.js
@@ -43,15 +43,15 @@ const login = async () => {
     try {
       response = await checkRegisteredUser();
     } catch (error) {
-      console.error(error);
-      response = error;
+        if(error.code === 401){
+            window.location.href = "./401.html";
+        }
+        console.error(error);
     }
     
     if (response.token) {
         window.location.href = "./index.html";
         localStorage.setItem("token", JSON.stringify(response.token));
-    }else{
-        window.location.href = "./401.html";
     }
 }
 

--- a/lesson26/src/js/login.js
+++ b/lesson26/src/js/login.js
@@ -49,7 +49,7 @@ const login = async () => {
         console.error(error);
     }
     
-    if (response.token) {
+    if (response?.token) {
         localStorage.setItem("token", JSON.stringify(response.token));
         window.location.href = "./index.html";
     }

--- a/lesson26/src/js/login.js
+++ b/lesson26/src/js/login.js
@@ -42,13 +42,15 @@ const login = async () => {
     let response;
     try {
       response = await checkRegisteredUser();
-    } catch {
-      window.location.href = "./401.html";
+    } catch (error) {
+      console.error(error);
     }
     
     if (response.token) {
         window.location.href = "./index.html";
         localStorage.setItem("token", JSON.stringify(response.token));
+    }else{
+        window.location.href = "./401.html";
     }
 }
 

--- a/lesson26/src/js/login.js
+++ b/lesson26/src/js/login.js
@@ -44,6 +44,7 @@ const login = async () => {
       response = await checkRegisteredUser();
     } catch (error) {
       console.error(error);
+      response = error;
     }
     
     if (response.token) {


### PR DESCRIPTION
# [課題No26](https://github.com/kenmori/handsonFrontend/blob/master/work/markup/1.md#26)
ログイン機能のエラー処理を修正しました。
## [CodeSandBox](https://codesandbox.io/s/github/nakagawamai/js-lesson/tree/fix/lesson26-4/lesson26) 

## PR Contents
- Changed the error handling part of the login function.

## Reasons for correction
In the previous code, all visitors were redirected to a 401 page even when an unexpected error was caught or when there was no token in the response.

## Functions already implemented in the previous PR
```
ログイン画面(login.html)を作ります
ユーザー名とメールアドレスどちらも入れられるinputにしてください
パスワードの実装は25と同じ。
パスワード忘れてた方 forgotpassword.htmlを作って遷移できるようにしてください。ページ内の実装はしないで良いです。
会員登録はこちらから課題24,25で作ったregister.htmlへ遷移できる。

パスワードは仮に固定値としてN302aoe3とし、メールアドレス、ご自身で決めたものでいいです。
(パスワードは固定値N302aoe3)
ログインページに遷移したらトークンがlocalStorageにあるかどうか確認してください。
(トークンはログインでメールアドレス、パスワードがあっていれば発行されます(下記※1で検証した時です)。
通常はAPIで受け取りますが今回はダミーで固定値として作ります)
トークンがあれば、コンテンツ画面ページへ、なければログインページをそのまま出します。
ログインページ内は送信ボタン押下時に。

{
  email: "kejimorita@gmail.com", // <- なんでも良いです
  password: "N302aoe3" // 固定値
}
// ※これらはレビュー時にレビュワーに教えてあげるかPRに書いて示してください
というものがsubmitの引数として渡ってきたら、
Promise を使ってnameとpasswordをそれぞれの値のプリミティブ比較で合っているか検証してください(※1)。
(ここのPromise辺りの実装はなんでもいいです)
サーバー内で検証していることを想定しているので、awaitしている関数内で行ってください。
合っていたらresolve、違う場合 reject。

その返値にトークンを返して判定してください。
返値のトークンは[Chance](https://chancejs.com/mobile/apple_token.html)を使用し生成してください。

// 成功時
{ token: "fafae92rfjafa03", ok: true, code: 200 }

// 失敗時
{ ok: false, code: 401 }
それに応じて画面ページか失敗しましたページへ遷移
成功したらそのtokenを、ログイン画面内でlocalStorageに埋め込んでください。
```
