### PR TITLE
Fixed validation check when clicking password show/hide button.

### DIFF
--- a/lesson26/src/js/login.js
+++ b/lesson26/src/js/login.js
@@ -62,7 +62,9 @@ const inputSelector = document.querySelectorAll('input');
 for (const input of inputSelector){
     input.classList.add("field-invalid");
 
-    input.addEventListener("blur", () => {
+    input.addEventListener("blur", (event) => {
+        if(isRelatedTogglePassword(event)) return;
+
         if(input.hasAttribute("required") && input.value.trim() === ""){
             validation.showErrorMessage(input,"入力してください");
         }else{
@@ -87,3 +89,8 @@ for (const input of inputSelector){
 }
 
 togglePasswordButton.addEventListener('click', () => togglePassword(passwordInput,togglePasswordButton));
+
+const isRelatedTogglePassword = (event) => {
+    const related = event.relatedTarget ? event.relatedTarget.id : "unknown";
+    return related === "js-toggle-password";
+}

--- a/lesson26/src/js/login.js
+++ b/lesson26/src/js/login.js
@@ -63,7 +63,7 @@ for (const input of inputSelector){
     input.classList.add("field-invalid");
 
     input.addEventListener("blur", (event) => {
-        if(isRelatedTogglePassword(event)) return;
+        if(isRelatedTarget(event,"js-toggle-password")) return;
 
         if(input.hasAttribute("required") && input.value.trim() === ""){
             validation.showErrorMessage(input,"入力してください");
@@ -90,7 +90,7 @@ for (const input of inputSelector){
 
 togglePasswordButton.addEventListener('click', () => togglePassword(passwordInput,togglePasswordButton));
 
-const isRelatedTogglePassword = (event) => {
+const isRelatedTarget = (event,target) => {
     const related = event.relatedTarget ? event.relatedTarget.id : "unknown";
-    return related === "js-toggle-password";
+    return related === target;
 }

--- a/lesson26/src/js/login.js
+++ b/lesson26/src/js/login.js
@@ -88,7 +88,10 @@ for (const input of inputSelector){
     });
 }
 
-togglePasswordButton.addEventListener('click', () => togglePassword(passwordInput,togglePasswordButton));
+togglePasswordButton.addEventListener('click', () => {
+    validation.removeErrorMessage(passwordInput);
+    togglePassword(passwordInput,togglePasswordButton);
+});
 
 togglePasswordButton.addEventListener('blur', (event) => {
     if(isRelatedTarget(event,"current-password")) return;

--- a/lesson26/src/js/login.js
+++ b/lesson26/src/js/login.js
@@ -88,11 +88,15 @@ for (const input of inputSelector){
     });
 }
 
-togglePasswordButton.addEventListener('click', () => togglePassword(passwordInput,togglePasswordButton));
+togglePasswordButton.addEventListener('click', () => {
+
+    togglePassword(passwordInput,togglePasswordButton);
+});
 
 togglePasswordButton.addEventListener('blur', (event) => {
     if(isRelatedTarget(event,"current-password")) return;
-
+    
+    validation.removeErrorMessage(passwordInput);
     validation.checkPassword(passwordInput);
     changeDisabledStatusSubmitButton();
 });

--- a/lesson26/src/js/login.js
+++ b/lesson26/src/js/login.js
@@ -90,6 +90,13 @@ for (const input of inputSelector){
 
 togglePasswordButton.addEventListener('click', () => togglePassword(passwordInput,togglePasswordButton));
 
+togglePasswordButton.addEventListener('blur', (event) => {
+    if(isRelatedTarget(event,"current-password")) return;
+
+    validation.checkPassword(passwordInput);
+    changeDisabledStatusSubmitButton();
+});
+
 const isRelatedTarget = (event,target) => {
     const related = event.relatedTarget ? event.relatedTarget.id : "unknown";
     return related === target;

--- a/lesson26/src/js/login.js
+++ b/lesson26/src/js/login.js
@@ -88,10 +88,7 @@ for (const input of inputSelector){
     });
 }
 
-togglePasswordButton.addEventListener('click', () => {
-
-    togglePassword(passwordInput,togglePasswordButton);
-});
+togglePasswordButton.addEventListener('click', () => togglePassword(passwordInput,togglePasswordButton));
 
 togglePasswordButton.addEventListener('blur', (event) => {
     if(isRelatedTarget(event,"current-password")) return;

--- a/lesson26/src/js/login.js
+++ b/lesson26/src/js/login.js
@@ -88,10 +88,7 @@ for (const input of inputSelector){
     });
 }
 
-togglePasswordButton.addEventListener('click', () => {
-    validation.removeErrorMessage(passwordInput);
-    togglePassword(passwordInput,togglePasswordButton);
-});
+togglePasswordButton.addEventListener('click', () => togglePassword(passwordInput,togglePasswordButton));
 
 togglePasswordButton.addEventListener('blur', (event) => {
     if(isRelatedTarget(event,"current-password")) return;

--- a/lesson26/src/js/register.js
+++ b/lesson26/src/js/register.js
@@ -84,10 +84,7 @@ toggleModal();
 const passwordInput = document.getElementById('new-password');
 const togglePasswordButton = document.getElementById('js-toggle-password');
 
-togglePasswordButton.addEventListener('click', () => {
-    validation.removeErrorMessage(passwordInput);
-    togglePassword(passwordInput,togglePasswordButton);
-});
+togglePasswordButton.addEventListener('click', () => togglePassword(passwordInput,togglePasswordButton));
 
 togglePasswordButton.addEventListener('blur', (event) => {
     if(isRelatedTarget(event,"new-password")) return;

--- a/lesson26/src/js/register.js
+++ b/lesson26/src/js/register.js
@@ -89,6 +89,7 @@ togglePasswordButton.addEventListener('click', () => togglePassword(passwordInpu
 togglePasswordButton.addEventListener('blur', (event) => {
     if(isRelatedTarget(event,"new-password")) return;
 
+    validation.removeErrorMessage(passwordInput);
     validation.checkPassword(passwordInput);
     changeDisabledStatusSubmitButton();
 });

--- a/lesson26/src/js/register.js
+++ b/lesson26/src/js/register.js
@@ -40,7 +40,9 @@ inputSelector[0].focus();
 for (const input of inputSelector){
     input.classList.add("field-invalid");
 
-    input.addEventListener("blur", () => {
+    input.addEventListener("blur", (event) => {
+        if(isRelatedTogglePassword(event)) return;
+
         if(input.hasAttribute("required") && input.value.trim() === ""){
             validation.showErrorMessage(input,"入力してください");
         }else{
@@ -83,3 +85,8 @@ const passwordInput = document.getElementById('new-password');
 const togglePasswordButton = document.getElementById('js-toggle-password');
 
 togglePasswordButton.addEventListener('click', () => togglePassword(passwordInput,togglePasswordButton));
+
+const isRelatedTogglePassword = (event) => {
+    const related = event.relatedTarget ? event.relatedTarget.id : "unknown";
+    return related === "js-toggle-password";
+}

--- a/lesson26/src/js/register.js
+++ b/lesson26/src/js/register.js
@@ -41,7 +41,7 @@ for (const input of inputSelector){
     input.classList.add("field-invalid");
 
     input.addEventListener("blur", (event) => {
-        if(isRelatedTogglePassword(event)) return;
+        if(isRelatedTarget(event,"js-toggle-password")) return;
 
         if(input.hasAttribute("required") && input.value.trim() === ""){
             validation.showErrorMessage(input,"入力してください");
@@ -84,9 +84,19 @@ toggleModal();
 const passwordInput = document.getElementById('new-password');
 const togglePasswordButton = document.getElementById('js-toggle-password');
 
-togglePasswordButton.addEventListener('click', () => togglePassword(passwordInput,togglePasswordButton));
+togglePasswordButton.addEventListener('click', () => {
+    validation.removeErrorMessage(passwordInput);
+    togglePassword(passwordInput,togglePasswordButton);
+});
 
-const isRelatedTogglePassword = (event) => {
+togglePasswordButton.addEventListener('blur', (event) => {
+    if(isRelatedTarget(event,"new-password")) return;
+
+    validation.checkPassword(passwordInput);
+    changeDisabledStatusSubmitButton();
+});
+
+const isRelatedTarget = (event,target) => {
     const related = event.relatedTarget ? event.relatedTarget.id : "unknown";
-    return related === "js-toggle-password";
+    return related === target;
 }


### PR DESCRIPTION
# [課題No26](https://github.com/kenmori/handsonFrontend/blob/master/work/markup/1.md#26)
パスワードの表示・非表示ボタンクリック時に、バリデーションチェックが走っていたため、
走らないように修正しました。

<img width="500" alt="スクリーンショット 2023-03-10 8 55 02" src="https://user-images.githubusercontent.com/99260576/224350247-318e0077-5a7f-4bba-b539-096219f52289.png">

## [CodeSandBox](https://codesandbox.io/s/github/nakagawamai/js-lesson/tree/fix/lesson26/lesson26) 

## Reasons for correction
Users only want to show or hide their passwords, so if validation checks are run when they click, they will be stressed.

## [Corresponding comment](https://github.com/nakagawamai/js-lesson/pull/32#issuecomment-1439331242)
> [nits]
When the Show Password button is pressed, validation runs, but the user may just want to show or hide the password.
That's what I was taught in my last review.
https://github.com/haru-programming/JavaScript-lessons/pull/40#issuecomment-1413659541
> 
> Using relatedTarget, you can identify the blur destination of the input.
> [Reference](https://developer.mozilla.org/ja/docs/Web/API/MouseEvent/relatedTarget)
> 
> Here is my correction. -> https://github.com/haru-programming/JavaScript-lessons/pull/40#issuecomment-1425779703
> Since it's NITS, I'll leave it to you to fix!

## Target file
- login.js
- register.js

## Functions already implemented in the previous PR
```
ログイン画面(login.html)を作ります
ユーザー名とメールアドレスどちらも入れられるinputにしてください
パスワードの実装は25と同じ。
パスワード忘れてた方 forgotpassword.htmlを作って遷移できるようにしてください。ページ内の実装はしないで良いです。
会員登録はこちらから課題24,25で作ったregister.htmlへ遷移できる。

パスワードは仮に固定値としてN302aoe3とし、メールアドレス、ご自身で決めたものでいいです。
(パスワードは固定値N302aoe3)
ログインページに遷移したらトークンがlocalStorageにあるかどうか確認してください。
(トークンはログインでメールアドレス、パスワードがあっていれば発行されます(下記※1で検証した時です)。
通常はAPIで受け取りますが今回はダミーで固定値として作ります)
トークンがあれば、コンテンツ画面ページへ、なければログインページをそのまま出します。
ログインページ内は送信ボタン押下時に。

{
  email: "kejimorita@gmail.com", // <- なんでも良いです
  password: "N302aoe3" // 固定値
}
// ※これらはレビュー時にレビュワーに教えてあげるかPRに書いて示してください
というものがsubmitの引数として渡ってきたら、
Promise を使ってnameとpasswordをそれぞれの値のプリミティブ比較で合っているか検証してください(※1)。
(ここのPromise辺りの実装はなんでもいいです)
サーバー内で検証していることを想定しているので、awaitしている関数内で行ってください。
合っていたらresolve、違う場合 reject。

その返値にトークンを返して判定してください。
返値のトークンは[Chance](https://chancejs.com/mobile/apple_token.html)を使用し生成してください。

// 成功時
{ token: "fafae92rfjafa03", ok: true, code: 200 }

// 失敗時
{ ok: false, code: 401 }
それに応じて画面ページか失敗しましたページへ遷移
成功したらそのtokenを、ログイン画面内でlocalStorageに埋め込んでください。
```
